### PR TITLE
Windows library name; fixes #3

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -187,7 +187,7 @@ gzread(s::GZipStream, p::Ptr, len::Integer) =
     @test_gzerror(s, ccall((:gzread, _zlib), Int32, (Ptr{Void}, Ptr{Void}, Uint32),
                            s.gz_file, p, len),                          -1)
 
-let _zlib_h = dlopen("libz")
+let _zlib_h = dlopen(_zlib)
     global gzbuffer, _gzopen, _gzseek, _gztell
 
     # Doesn't exist in zlib 1.2.3 or earlier

--- a/src/zlib_h.jl
+++ b/src/zlib_h.jl
@@ -79,7 +79,7 @@ const SEEK_CUR = int32(1)
 # Get compile-time option flags
 zlib_compile_flags = ccall((:zlibCompileFlags, _zlib), Uint, ())
 
-let _zlib_h = dlopen("libz")
+let _zlib_h = dlopen(_zlib)
     global ZFileOffset
 
     z_off_t_sz   = 2 << ((zlib_compile_flags >> 6) & uint(3))


### PR DESCRIPTION
I finally got around to getting the right .dll. Trying to load though, I got a few more errors that were confusing at first, but looking into it, there are just a few other places where the library name was hardcoded "libz". Fixes issue #3 
