### PR TITLE
Use try/finally in gzopen(func,...)

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -248,12 +248,9 @@ open(args...) = gzopen(args...)
 
 function gzopen(f::Function, args...)
     io = gzopen(args...)
-    x = try f(io) catch err
-        close(io)
-        throw(err)
+    try f(io)
+    finally close(io)
     end
-    close(io)
-    return x
 end
 
 function gzdopen(name::String, fd::Integer, gzmode::String, gz_buf_size::Integer)


### PR DESCRIPTION
Leaner code + simplifies debugging by preserving the original backtrace.
