### PR TITLE
Base.nb_available(GZipSteam)

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -5,7 +5,7 @@ module GZip
 using Compat
 import Base: show, fd, close, flush, truncate, seek,
              seekend, skip, position, eof, read, readstring,
-             readline, write, unsafe_write, peek
+             readline, write, unsafe_write, peek, nb_available
 
 export
   GZipStream,
@@ -351,6 +351,8 @@ position(s::GZipStream, raw::Bool=false) =
 end
 
 eof(s::GZipStream) = Bool(ccall((:gzeof, _zlib), Int32, (Ptr{Void},), s.gz_file))
+
+nb_available(s::GZipStream) = eof(s) ? 0 : 1 # FIXME return the number of buffered bytes
 
 function peek(s::GZipStream)
     c = gzgetc_raw(s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,7 @@ try
     # Test gzfdio
     raw_file = open(test_compressed, "r")
     gzfile = gzdopen(fd(raw_file), "r")
+    @test nb_available(gzfile) > 0
     data4 = readstring(gzfile)
     close(gzfile)
     close(raw_file)
@@ -60,9 +61,11 @@ try
 
     # Test peek
     gzfile = gzopen(test_compressed, "r")
+    @test nb_available(gzfile) > 0
     @test peek(gzfile) == UInt(first_char)
     readstring(gzfile)
     @test peek(gzfile) == -1
+    @test nb_available(gzfile) == 0
     close(gzfile)
 
     # Screw up the file
@@ -164,6 +167,7 @@ try
     @test close(gzfile) == Z_OK
     gzfile = gzopen(test_compressed, "r")
     @test eof(gzfile) == true
+    @test nb_available(gzfile) == 0
     @test close(gzfile) == Z_OK
 
     ##########################


### PR DESCRIPTION
Basic `Base.nb_available(GZipSteam)` implementation that returns 1 if the stream is not exhausted, 0 otherwise.

Came across the issue while trying to make https://github.com/JuliaData/CSV.jl read .csv.gz files from `GZipStream`.