### PR TITLE
Add seekend function

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -335,6 +335,12 @@ function seek(s::GZipStream, n::Integer)
         error("seek (gzseek) failed")
 end
 
+function seekend(s::GZipStream)
+    seek(s, 0)
+    indmax(eachline(s))
+    return s
+end
+
 # Note: skips bytes within uncompressed data stream
 skip(s::GZipStream, n::Integer) =
     (ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Void}, ZFileOffset, Int32),


### PR DESCRIPTION
Although zlib does not support seekend, it is possible to set the position to the end by calling a function (in this case I use `indmax` but other functions work too) on the `EachLines` of the GZipStream.