### PR TITLE
fixes for 0.7, require at least 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
     - osx
     - linux
 julia:
-    - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,74 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "IterativeEigensolvers", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "SuiteSparse", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "e891dc2ba653107604985bc5ab7294d9de83630f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "0.66.0"
+
+[[Dates]]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[InteractiveUtils]]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterativeEigensolvers]]
+uuid = "de555fa4-b82f-55e7-8b71-53f60bbc027d"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Markdown]]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SuiteSparse]]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[Test]]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,7 @@
+authors = ["Rene Donner <code@donner.at>"]
+name = "GZip"
+uuid = "bd813960-689d-11e8-3c5e-13d7b8681304"
+version = "0.1.0"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-Compat 0.9.5
+julia 0.6
+Compat #0.64  use version providing readuntil

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -80,23 +80,30 @@ const GZLIB_VERSION = unsafe_string(ccall((:zlibVersion, GZip._zlib), Ptr{UInt8}
 const GZ_LINE_BUFSIZE = 256
 
 # Wrapper around gzFile
-type GZipStream <: IO
+mutable struct GZipStream <: IO
     name::AbstractString
-    gz_file::Ptr{Void}
+    gz_file::Ptr{Nothing}
     buf_size::Int
 
     _closed::Bool
 
-    GZipStream(name::AbstractString, gz_file::Ptr{Void}, buf_size::Int) =
-        (x = new(name, gz_file, buf_size, false); finalizer(x, close); x)
+    function GZipStream(name::AbstractString, gz_file::Ptr{Nothing}, buf_size::Int)
+        x = new(name, gz_file, buf_size, false)
+        if VERSION < v"0.7-"
+            finalizer(x, close)
+        else
+            finalizer(close, x)
+        end
+        x
+    end
 end
-GZipStream(name::AbstractString, gz_file::Ptr{Void}) = GZipStream(name, gz_file, Z_DEFAULT_BUFSIZE)
+GZipStream(name::AbstractString, gz_file::Ptr{Nothing}) = GZipStream(name, gz_file, Z_DEFAULT_BUFSIZE)
 
 # gzerror
 function gzerror(err::Integer, s::GZipStream)
     e = Int32[err]
     if !s._closed
-        msg_p = ccall((:gzerror, _zlib), Ptr{UInt8}, (Ptr{Void}, Ptr{Int32}),
+        msg_p = ccall((:gzerror, _zlib), Ptr{UInt8}, (Ptr{Nothing}, Ptr{Int32}),
                       s.gz_file, e)
         msg = (msg_p == C_NULL ? "" : unsafe_string(msg_p))
     else
@@ -106,7 +113,7 @@ function gzerror(err::Integer, s::GZipStream)
 end
 gzerror(s::GZipStream) = gzerror(0, s)
 
-type GZError <: Exception
+mutable struct GZError <: Exception
     err::Int32
     err_str::AbstractString
 
@@ -166,49 +173,49 @@ end
 
 # Easy access to gz reading/writing functions (Internal)
 gzgetc(s::GZipStream) =
-    @test_eof_gzerr(s, ccall((:gzgetc, _zlib), Int32, (Ptr{Void},), s.gz_file), -1)
+    @test_eof_gzerr(s, ccall((:gzgetc, _zlib), Int32, (Ptr{Nothing},), s.gz_file), -1)
 
-gzgetc_raw(s::GZipStream) = ccall((:gzgetc, _zlib), Int32, (Ptr{Void},), s.gz_file)
+gzgetc_raw(s::GZipStream) = ccall((:gzgetc, _zlib), Int32, (Ptr{Nothing},), s.gz_file)
 
 gzungetc(c::Integer, s::GZipStream) =
-    @test_eof_gzerr(s, ccall((:gzungetc, _zlib), Int32, (Int32, Ptr{Void}), c, s.gz_file), -1)
+    @test_eof_gzerr(s, ccall((:gzungetc, _zlib), Int32, (Int32, Ptr{Nothing}), c, s.gz_file), -1)
 
 gzgets(s::GZipStream, a::Array{UInt8}) =
     @test_eof_gzerr2(s,
-                     ccall((:gzgets, _zlib), Ptr{UInt8}, (Ptr{Void}, Ptr{UInt8}, Int32),
+                     ccall((:gzgets, _zlib), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt8}, Int32),
                            s.gz_file, a, Int32(length(a))),
                      C_NULL)
 
 gzgets(s::GZipStream, p::Ptr{UInt8}, len::Integer) =
     @test_eof_gzerr2(s,
-                     ccall((:gzgets, _zlib), Ptr{UInt8}, (Ptr{Void}, Ptr{UInt8}, Int32),
+                     ccall((:gzgets, _zlib), Ptr{UInt8}, (Ptr{Nothing}, Ptr{UInt8}, Int32),
                            s.gz_file, p, Int32(len)),
                      C_NULL)
 
 gzputc(s::GZipStream, c::Integer) =
     @test_gzerror(s,
-                  ccall((:gzputc, _zlib), Int32, (Ptr{Void}, Int32),
+                  ccall((:gzputc, _zlib), Int32, (Ptr{Nothing}, Int32),
                         s.gz_file, Int32(c)),
                   -1)
 
 gzwrite(s::GZipStream, p::Ptr, len::Integer) =
     len == 0 ? Int32(0) :
-               @test_gzerror0(s, ccall((:gzwrite, _zlib), Int32, (Ptr{Void}, Ptr{Void}, UInt32),
+               @test_gzerror0(s, ccall((:gzwrite, _zlib), Int32, (Ptr{Nothing}, Ptr{Nothing}, UInt32),
                                        s.gz_file, p, len))
 
 gzread(s::GZipStream, p::Ptr, len::Integer) =
     @test_gzerror(s,
-                  ccall((:gzread, _zlib), Int32, (Ptr{Void}, Ptr{Void}, UInt32),
+                  ccall((:gzread, _zlib), Int32, (Ptr{Nothing}, Ptr{Nothing}, UInt32),
                         s.gz_file, p, len),
                   -1)
 
-let _zlib_h = Libdl.dlopen(_zlib)
+let _zlib_h = Compat.Libdl.dlopen(_zlib)
     global gzbuffer, _gzopen, _gzseek, _gztell, _gzrewind, _gzdirect, _gzoffset
 
     # Doesn't exist in zlib 1.2.3 or earlier
-    if Libdl.dlsym_e(_zlib_h, :gzbuffer) != C_NULL
+    if Compat.Libdl.dlsym_e(_zlib_h, :gzbuffer) != C_NULL
         gzbuffer(gz_file::Ptr, gz_buf_size::Integer) =
-           ccall((:gzbuffer, _zlib), Int32, (Ptr{Void}, UInt32), gz_file, gz_buf_size)
+           ccall((:gzbuffer, _zlib), Int32, (Ptr{Nothing}, UInt32), gz_file, gz_buf_size)
     else
         gzbuffer(gz_file::Ptr, gz_buf_size::Integer) = Int32(-1)
     end
@@ -217,7 +224,7 @@ let _zlib_h = Libdl.dlopen(_zlib)
 
     # Use 64-bit functions if available
 
-    if Libdl.dlsym_e(_zlib_h, :gzopen64) != C_NULL
+    if Compat.Libdl.dlsym_e(_zlib_h, :gzopen64) != C_NULL
         const _gzopen = :gzopen64
         const _gzseek = :gzseek64
         const _gztell = :gztell64
@@ -245,7 +252,7 @@ function gzopen(fname::AbstractString, gzmode::AbstractString, gz_buf_size::Inte
         gzmode *= "b"
     end
 
-    gz_file = ccall((_gzopen, _zlib), Ptr{Void}, (Ptr{UInt8}, Ptr{UInt8}), fname, gzmode)
+    gz_file = ccall((_gzopen, _zlib), Ptr{Nothing}, (Ptr{UInt8}, Ptr{UInt8}), fname, gzmode)
     if gz_file == C_NULL
         throw(GZError(-1, "gzopen failed"))
     end
@@ -279,7 +286,7 @@ function gzdopen(name::AbstractString, fd::Integer, gzmode::AbstractString, gz_b
     # not to close the original fd
     dup_fd = ccall(:dup, Int32, (Int32,), fd)
 
-    gz_file = ccall((:gzdopen, _zlib), Ptr{Void}, (Int32, Ptr{UInt8}), dup_fd, gzmode)
+    gz_file = ccall((:gzdopen, _zlib), Ptr{Nothing}, (Int32, Ptr{UInt8}), dup_fd, gzmode)
     if gz_file == C_NULL
         throw(GZError(-1, "gzdopen failed"))
     end
@@ -310,13 +317,13 @@ function close(s::GZipStream)
 
     s.name *= " (closed)"
 
-    ret = (@test_z_ok ccall((:gzclose, _zlib), Int32, (Ptr{Void},), s.gz_file))
+    ret = (@test_z_ok ccall((:gzclose, _zlib), Int32, (Ptr{Nothing},), s.gz_file))
 
     return ret
 end
 
 flush(s::GZipStream, fl::Integer) =
-    @test_z_ok ccall((:gzflush, _zlib), Int32, (Ptr{Void}, Int32), s.gz_file, Int32(fl))
+    @test_z_ok ccall((:gzflush, _zlib), Int32, (Ptr{Nothing}, Int32), s.gz_file, Int32(fl))
 flush(s::GZipStream) = flush(s, Z_SYNC_FLUSH)
 
 truncate(s::GZipStream, n::Integer) = throw(MethodError(truncate, (GZipStream, Integer)))
@@ -324,33 +331,33 @@ truncate(s::GZipStream, n::Integer) = throw(MethodError(truncate, (GZipStream, I
 # Note: seeks to byte position within uncompressed data stream
 function seek(s::GZipStream, n::Integer)
     # Note: band-aid to avoid a bug occurring on uncompressed files under Windows
-    @static if is_windows()
-        if (ccall((_gzdirect, _zlib), Cint, (Ptr{Void},), s.gz_file)) == 1
-            ccall((_gzrewind, _zlib), Cint, (Ptr{Void},), s.gz_file)!=-1 ||
+    @static if Compat.Sys.iswindows()
+        if (ccall((_gzdirect, _zlib), Cint, (Ptr{Nothing},), s.gz_file)) == 1
+            ccall((_gzrewind, _zlib), Cint, (Ptr{Nothing},), s.gz_file)!=-1 ||
                 error("seek (gzseek) failed")
         end
     end
-    ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Void}, ZFileOffset, Int32),
+    ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Nothing}, ZFileOffset, Int32),
            s.gz_file, n, SEEK_SET)!=-1 || # Mimick behavior of seek(s::IOStream, n)
         error("seek (gzseek) failed")
 end
 
 # Note: skips bytes within uncompressed data stream
 skip(s::GZipStream, n::Integer) =
-    (ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Void}, ZFileOffset, Int32),
+    (ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Nothing}, ZFileOffset, Int32),
            s.gz_file, n, SEEK_CUR)!=-1 ||
      error("skip (gzseek) failed")) # Mimick behavior of skip(s::IOStream, n)
 
 if GZLIB_VERSION > "1.2.3.9"
 position(s::GZipStream, raw::Bool=false) = raw ?
-    ccall((_gzoffset, _zlib), ZFileOffset, (Ptr{Void},), s.gz_file) :
-      ccall((_gztell, _zlib), ZFileOffset, (Ptr{Void},), s.gz_file)
+    ccall((_gzoffset, _zlib), ZFileOffset, (Ptr{Nothing},), s.gz_file) :
+      ccall((_gztell, _zlib), ZFileOffset, (Ptr{Nothing},), s.gz_file)
 else
 position(s::GZipStream, raw::Bool=false) =
-      ccall((_gztell, _zlib), ZFileOffset, (Ptr{Void},), s.gz_file)
+      ccall((_gztell, _zlib), ZFileOffset, (Ptr{Nothing},), s.gz_file)
 end
 
-eof(s::GZipStream) = Bool(ccall((:gzeof, _zlib), Int32, (Ptr{Void},), s.gz_file))
+eof(s::GZipStream) = Bool(ccall((:gzeof, _zlib), Int32, (Ptr{Nothing},), s.gz_file))
 
 function peek(s::GZipStream)
     c = gzgetc_raw(s)
@@ -361,12 +368,12 @@ function peek(s::GZipStream)
 end
 
 # Mimics read(s::IOStream, a::Array{T})
-function read{T}(s::GZipStream, a::Array{T})
+function read(s::GZipStream, a::Array{T}) where {T}
     if isbits(T)
         nb = length(a)*sizeof(T)
         # Note: this will overflow and succeed without warning if nb > 4GB
         ret = ccall((:gzread, _zlib), Int32,
-                    (Ptr{Void}, Ptr{Void}, UInt32), s.gz_file, a, nb)
+                    (Ptr{Nothing}, Ptr{Nothing}, UInt32), s.gz_file, a, nb)
         if ret == -1
             throw(GZError(s))
         end
@@ -393,7 +400,7 @@ end
 # For this function, it's really unfortunate that zlib is
 # not integrated with ios
 function readstring(s::GZipStream, bufsize::Int)
-    buf = Array{UInt8}(bufsize)
+    buf = Array{UInt8}(undef,bufsize)
     len = 0
     while true
         ret = gzread(s, pointer(buf)+len, bufsize)
@@ -424,7 +431,7 @@ end
 readstring(s::GZipStream) = readstring(s, Z_BIG_BUFSIZE)
 
 function readline(s::GZipStream)
-    buf = Array{UInt8}(GZ_LINE_BUFSIZE)
+    buf = Array{UInt8}(undef,GZ_LINE_BUFSIZE)
     pos = 1
 
     if gzgets(s, buf) == C_NULL      # Throws an exception on error
@@ -433,7 +440,11 @@ function readline(s::GZipStream)
 
     while(true)
         # since gzgets didn't return C_NULL, there must be a \0 in the buffer
-        eos = search(buf, '\0', pos)
+        if VERSION < v"0.7-"
+            eos = search(buf, '\0', pos)
+        else
+            eos = coalesce(findnext(isequal(UInt8('\0')), buf, pos), 0)
+        end
         if eos == 1 || buf[eos-1] == UInt8('\n')
             return String(copy(resize!(buf, eos-1)))
         end
@@ -462,7 +473,7 @@ write(s::GZipStream, b::UInt8) = gzputc(s, b)
 write(s::GZipStream, a::Array{UInt8}) = gzwrite(s, pointer(a), sizeof(a))
 unsafe_write(s::GZipStream, p::Ptr{UInt8}, nb::UInt) = gzwrite(s, p, nb)
 
-function write{T,N}(s::GZipStream, a::SubArray{T,N,Array})
+function write(s::GZipStream, a::SubArray{T,N,Array}) where {T,N}
     if !isbits(T) || stride(a,1)!=1
         return invoke(write, Tuple{Any,AbstractArray}, s, a)
     end

--- a/src/zlib_h.jl
+++ b/src/zlib_h.jl
@@ -1,8 +1,8 @@
 # general zlib constants, definitions
 
-if is_unix()
+if Compat.Sys.isunix()
     const _zlib = "libz"
-elseif is_windows()
+elseif Compat.Sys.iswindows()
     const _zlib = "zlib1"
 end
 
@@ -34,7 +34,7 @@ const Z_VERSION_ERROR  =  Int32(-6)
 
 # Zlib errors as Exceptions
 zerror(e::Integer) =  unsafe_string(ccall((:zError, _zlib), Ptr{UInt8}, (Int32,), e))
-type ZError <: Exception
+mutable struct ZError <: Exception
     err::Int32
     err_str::AbstractString
 
@@ -81,7 +81,7 @@ const SEEK_CUR =  Int32(1)
 # Get compile-time option flags
 const zlib_compile_flags = ccall((:zlibCompileFlags, _zlib), UInt, ())
 const z_off_t_sz = 2 << ((zlib_compile_flags >> 6) & UInt(3))
-if (z_off_t_sz == 8 || Libdl.dlsym_e(Libdl.dlopen(_zlib), :gzopen64) != C_NULL)
+if (z_off_t_sz == 8 || Compat.Libdl.dlsym_e(Libdl.dlopen(_zlib), :gzopen64) != C_NULL)
     const ZFileOffset = Int64
 elseif z_off_t_sz == 4
     const ZFileOffset = Int32

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Compat
-pushfirst!(LOAD_PATH, joinpath(dirname(@__FILE__), "../src"))
 
 using GZip
 using Compat.Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
+using Compat
+pushfirst!(LOAD_PATH, joinpath(dirname(@__FILE__), "../src"))
+
 using GZip
-using Base.Test
+using Compat.Test
 
 ##########################
 # test_context("GZip tests")
@@ -13,17 +16,17 @@ test_infile = @__FILE__
 test_compressed = joinpath(tmp, "runtests.jl.gz")
 test_empty = joinpath(tmp, "empty.jl.gz")
 
-if is_windows()
+if Compat.Sys.iswindows()
     gunzip = "gunzip.exe"
-elseif is_unix()
+elseif Compat.Sys.isunix()
     gunzip = "gunzip"
 end
 
-test_gunzip = true
+global test_gunzip = true
 try
-    run(pipeline(`which $gunzip`, DevNull))
+    run(pipeline(`which $gunzip`, devnull))
 catch
-    test_gunzip = false
+    global test_gunzip = false
 end
 
 try
@@ -31,7 +34,7 @@ try
     # test_group("Compress Test1: gzip.jl")
     ##########################
 
-    data = open(readstring, test_infile);
+    data = open(x->read(x,String), test_infile);
 
     first_char = data[1]
 
@@ -43,17 +46,17 @@ try
     @test_throws EOFError write(gzfile, data)
 
     if test_gunzip
-        data2 = readstring(`$gunzip -c $test_compressed`)
+        data2 = read(`$gunzip -c $test_compressed`, String)
         @test data == data2
     end
 
-    data3 = gzopen(readstring, test_compressed)
+    data3 = gzopen(x->read(x,String), test_compressed)
     @test data == data3
 
     # Test gzfdio
     raw_file = open(test_compressed, "r")
     gzfile = gzdopen(fd(raw_file), "r")
-    data4 = readstring(gzfile)
+    data4 = read(gzfile, String)
     close(gzfile)
     close(raw_file)
     @test data == data4
@@ -61,7 +64,7 @@ try
     # Test peek
     gzfile = gzopen(test_compressed, "r")
     @test peek(gzfile) == UInt(first_char)
-    readstring(gzfile)
+    read(gzfile, String)
     @test peek(gzfile) == -1
     close(gzfile)
 
@@ -72,7 +75,7 @@ try
     close(raw_file)
 
     try
-        gzopen(readstring, test_compressed)
+        gzopen(x->read(x,String), test_compressed)
         throw(ErrorException("Expecting ArgumentError or similar"))
     catch ex
         @test typeof(ex) <: Union{ArgumentError,ZError,GZError} ||
@@ -147,7 +150,7 @@ try
             # readuntil test
             seek(gzf, 0)
             while !eof(gzf)
-                write(s, readuntil(gzf, 'a'))
+                write(s, Compat.readuntil(gzf, 'a', keep = true))
             end
             data3 = String(take!(s));
             close(gzf)
@@ -173,7 +176,7 @@ try
     let BUFSIZE = 65536
         for level = 0:3:6
             for T in [Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128,
-                      Float32,Float64,Complex64,Complex128]
+                      Float32,Float64,ComplexF32,ComplexF64]
 
                 minval = 34567
                 try
@@ -197,9 +200,9 @@ try
                 # Random array
                 if isa(T, AbstractFloat)
                     r = (T)[rand(BUFSIZE)...];
-                elseif isa(T, Complex64)
+                elseif isa(T, ComplexF32)
                     r = Int32[rand(BUFSIZE)...] + Int32[rand(BUFSIZE)...] * im
-                elseif isa(T, Complex128)
+                elseif isa(T, ComplexF64)
                     r = Int64[rand(BUFSIZE)...] + Int64[rand(BUFSIZE)...] * im
                 else
                     r = b[rand(1:BUFSIZE, BUFSIZE)];


### PR DESCRIPTION
Tests pass without warnings on 0.6 and 0.7.

Needs `readuntil` fix to Compat to pass on 0.6: https://github.com/JuliaLang/Compat.jl/pull/525.