### PR TITLE
Fixes for julia 0.7, drop support for 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - linux
 julia:
     - 0.6
+    - 0.7
     - nightly
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
     - osx
     - linux
 julia:
-    - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # GZip.jl: A Julia interface for gzip functions in zlib
 
-[![GZip](http://pkg.julialang.org/badges/GZip_0.3.svg)](http://pkg.julialang.org/?pkg=GZip)
-[![GZip](http://pkg.julialang.org/badges/GZip_0.4.svg)](http://pkg.julialang.org/?pkg=GZip)
-[![GZip](http://pkg.julialang.org/badges/GZip_0.5.svg)](http://pkg.julialang.org/?pkg=GZip)
 [![GZip](http://pkg.julialang.org/badges/GZip_0.6.svg)](http://pkg.julialang.org/?pkg=GZip)
+[![GZip](http://pkg.julialang.org/badges/GZip_0.7.svg)](http://pkg.julialang.org/?pkg=GZip)
 [![Build Status](https://travis-ci.org/JuliaIO/GZip.jl.svg?branch=master)](https://travis-ci.org/JuliaIO/GZip.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaIO/GZip.jl/badge.svg)](https://coveralls.io/r/JuliaIO/GZip.jl)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GZip](http://pkg.julialang.org/badges/GZip_0.3.svg)](http://pkg.julialang.org/?pkg=GZip)
 [![GZip](http://pkg.julialang.org/badges/GZip_0.4.svg)](http://pkg.julialang.org/?pkg=GZip)
 [![GZip](http://pkg.julialang.org/badges/GZip_0.5.svg)](http://pkg.julialang.org/?pkg=GZip)
+[![GZip](http://pkg.julialang.org/badges/GZip_0.6.svg)](http://pkg.julialang.org/?pkg=GZip)
 [![Build Status](https://travis-ci.org/JuliaIO/GZip.jl.svg?branch=master)](https://travis-ci.org/JuliaIO/GZip.jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaIO/GZip.jl/badge.svg)](https://coveralls.io/r/JuliaIO/GZip.jl)
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.41.0
+Compat 0.69.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-Compat 0.9.5
+julia 0.6
+Compat 0.41.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
@@ -17,6 +17,7 @@ notifications:
     on_build_status_changed: false
 
 install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
 # if there's a newer build queued for the same PR, cancel this one
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
@@ -24,7 +25,7 @@ install:
         throw "There are newer queued builds for this pull request, failing early." }
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        $env:JULIA_URL,
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -5,6 +5,7 @@ module GZip
 using Compat
 using Compat.Sys: iswindows
 using Compat.Libdl
+using Base.Libc
 import Base: show, fd, close, flush, truncate, seek,
              seekend, skip, position, eof, read, readstring,
              readline, write, unsafe_write, peek
@@ -282,7 +283,7 @@ function gzdopen(name::AbstractString, fd::Integer, gzmode::AbstractString, gz_b
 
     # Duplicate the file descriptor, since we have no way to tell gzclose()
     # not to close the original fd
-    dup_fd = ccall(:dup, Int32, (Int32,), fd)
+    dup_fd = Libc.dup(Libc.RawFD(fd))
 
     gz_file = ccall((:gzdopen, _zlib), Ptr{Nothing}, (Int32, Ptr{UInt8}), dup_fd, gzmode)
     if gz_file == C_NULL

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -223,7 +223,7 @@ let _zlib_h = Libdl.dlopen(_zlib)
 
     # Use 64-bit functions if available
 
-    if Libdl.dlsym_e(_zlib_h, :gzopen64) != C_NULL
+    if Libdl.dlsym_e(_zlib_h, :gzopen64) != C_NULL && (z_off_t_sz == 8 || !iswindows())
         const _gzopen = :gzopen64
         const _gzseek = :gzseek64
         const _gztell = :gztell64
@@ -337,7 +337,7 @@ function seek(s::GZipStream, n::Integer)
         end
     end
     ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Nothing}, ZFileOffset, Int32),
-           s.gz_file, n, SEEK_SET)!=-1 || # Mimick behavior of seek(s::IOStream, n)
+           s.gz_file, n, SEEK_SET)!=-1 || # Mimic behavior of seek(s::IOStream, n)
         error("seek (gzseek) failed")
 end
 
@@ -345,7 +345,7 @@ end
 skip(s::GZipStream, n::Integer) =
     (ccall((_gzseek, _zlib), ZFileOffset, (Ptr{Nothing}, ZFileOffset, Int32),
            s.gz_file, n, SEEK_CUR)!=-1 ||
-     error("skip (gzseek) failed")) # Mimick behavior of skip(s::IOStream, n)
+     error("skip (gzseek) failed")) # Mimic behavior of skip(s::IOStream, n)
 
 if GZLIB_VERSION > "1.2.3.9"
 position(s::GZipStream, raw::Bool=false) = raw ?

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -92,7 +92,7 @@ mutable struct GZipStream <: IO
 
     function GZipStream(name::AbstractString, gz_file::Ptr{Cvoid}, buf_size::Int)
         x = new(name, gz_file, buf_size, false)
-        VERSION ≥ v"0.7.0-DEV.2562" ? finalizer(close, x) : finalizer(x, close)
+        @compat finalizer(close, x)
         x
     end
 end

--- a/src/zlib_h.jl
+++ b/src/zlib_h.jl
@@ -83,7 +83,7 @@ const SEEK_CUR =  Int32(1)
 # Get compile-time option flags
 const zlib_compile_flags = ccall((:zlibCompileFlags, _zlib), UInt, ())
 const z_off_t_sz = 2 << ((zlib_compile_flags >> 6) & UInt(3))
-if (z_off_t_sz == 8 || Libdl.dlsym_e(Libdl.dlopen(_zlib), :gzopen64) != C_NULL)
+if z_off_t_sz == 8 || (!iswindows() && Libdl.dlsym_e(Libdl.dlopen(_zlib), :gzopen64) != C_NULL)
     const ZFileOffset = Int64
 elseif z_off_t_sz == 4
     const ZFileOffset = Int32

--- a/src/zlib_h.jl
+++ b/src/zlib_h.jl
@@ -1,8 +1,10 @@
 # general zlib constants, definitions
 
-if is_unix()
+using Compat.Sys: isunix, iswindows
+
+@static if isunix()
     const _zlib = "libz"
-elseif is_windows()
+elseif iswindows()
     const _zlib = "zlib1"
 end
 
@@ -34,7 +36,7 @@ const Z_VERSION_ERROR  =  Int32(-6)
 
 # Zlib errors as Exceptions
 zerror(e::Integer) =  unsafe_string(ccall((:zError, _zlib), Ptr{UInt8}, (Int32,), e))
-type ZError <: Exception
+mutable struct ZError <: Exception
     err::Int32
     err_str::AbstractString
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,13 @@
 using GZip
-using Base.Test
+using Compat
+using Compat.Test
+using Compat.Sys: isunix, iswindows
+
+@static if VERSION < v"0.7.0-DEV.3510"
+    readuntilkeep(args...) = readuntil(args...)
+else
+    readuntilkeep(args...) = readuntil(args...; keep = true)
+end
 
 ##########################
 # test_context("GZip tests")
@@ -13,16 +21,17 @@ test_infile = @__FILE__
 test_compressed = joinpath(tmp, "runtests.jl.gz")
 test_empty = joinpath(tmp, "empty.jl.gz")
 
-if is_windows()
+@static if iswindows()
     gunzip = "gunzip.exe"
-elseif is_unix()
+elseif isunix()
     gunzip = "gunzip"
 end
 
 test_gunzip = true
 try
-    run(pipeline(`which $gunzip`, DevNull))
+    run(pipeline(`which $gunzip`, devnull))
 catch
+    global test_gunzip
     test_gunzip = false
 end
 
@@ -31,7 +40,7 @@ try
     # test_group("Compress Test1: gzip.jl")
     ##########################
 
-    data = open(readstring, test_infile);
+    data = open(x->read(x, String), test_infile);
 
     first_char = data[1]
 
@@ -43,17 +52,17 @@ try
     @test_throws EOFError write(gzfile, data)
 
     if test_gunzip
-        data2 = readstring(`$gunzip -c $test_compressed`)
+        data2 = read(`$gunzip -c $test_compressed`, String)
         @test data == data2
     end
 
-    data3 = gzopen(readstring, test_compressed)
+    data3 = gzopen(x->read(x, String), test_compressed)
     @test data == data3
 
     # Test gzfdio
     raw_file = open(test_compressed, "r")
     gzfile = gzdopen(fd(raw_file), "r")
-    data4 = readstring(gzfile)
+    data4 = read(gzfile, String)
     close(gzfile)
     close(raw_file)
     @test data == data4
@@ -61,7 +70,7 @@ try
     # Test peek
     gzfile = gzopen(test_compressed, "r")
     @test peek(gzfile) == UInt(first_char)
-    readstring(gzfile)
+    read(gzfile, String)
     @test peek(gzfile) == -1
     close(gzfile)
 
@@ -72,7 +81,7 @@ try
     close(raw_file)
 
     try
-        gzopen(readstring, test_compressed)
+        gzopen(x->read(x, String), test_compressed)
         throw(ErrorException("Expecting ArgumentError or similar"))
     catch ex
         @test typeof(ex) <: Union{ArgumentError,ZError,GZError} ||
@@ -147,7 +156,7 @@ try
             # readuntil test
             seek(gzf, 0)
             while !eof(gzf)
-                write(s, readuntil(gzf, 'a'))
+                write(s, readuntilkeep(gzf, 'a'))
             end
             data3 = String(take!(s));
             close(gzf)
@@ -173,7 +182,7 @@ try
     let BUFSIZE = 65536
         for level = 0:3:6
             for T in [Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128,
-                      Float32,Float64,Complex64,Complex128]
+                      Float32,Float64,ComplexF32,ComplexF64]
 
                 minval = 34567
                 try
@@ -197,9 +206,9 @@ try
                 # Random array
                 if isa(T, AbstractFloat)
                     r = (T)[rand(BUFSIZE)...];
-                elseif isa(T, Complex64)
+                elseif isa(T, ComplexF32)
                     r = Int32[rand(BUFSIZE)...] + Int32[rand(BUFSIZE)...] * im
-                elseif isa(T, Complex128)
+                elseif isa(T, ComplexF64)
                     r = Int64[rand(BUFSIZE)...] + Int64[rand(BUFSIZE)...] * im
                 else
                     r = b[rand(1:BUFSIZE, BUFSIZE)];


### PR DESCRIPTION
This fixes all the errors and warnings on Julia 0.7 alpha. Tests pass locally.
Supersedes #67 and #65.