### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GZip"
 uuid = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 authors = ["staticfloat@gmail.com <staticfloat@gmail.com>"]
-version = "0.4.0"
+version = "0.5.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"


### PR DESCRIPTION
I see very few changes [since the last release](https://github.com/JuliaIO/GZip.jl/compare/JuliaIO:d5b1c32...JuliaIO:932f5dd), #84 is the only one that changed something under `src/` and it was a bugfix, so I'm incrementing the patch number only.  Note that the [last release](https://github.com/JuliaIO/GZip.jl/releases) was v0.5.0, no idea why the version in `Project.toml` hadn't been bumped...