### PR TITLE
Fix UndefVarError: `zError` not defined

### DIFF
--- a/src/zlib.jl
+++ b/src/zlib.jl
@@ -57,7 +57,7 @@ else
 end
 
 # Zlib errors as Exceptions
-zerror(e::Integer) = unsafe_string(zError(e))
+zerror(e::Integer) = unsafe_string(Zlib_h.zError(e))
 mutable struct ZError <: Exception
     err::Cint
     err_str::AbstractString


### PR DESCRIPTION
It is a small & obvious fix. `zError` is not exported by `ZLib_h` so the current version (after the refactor https://github.com/JuliaIO/GZip.jl/pull/101) will throw an `UndefVarError` whenever a `zerror` happens.