### PR TITLE
Fix linear buffer growth in read(::GZipStream, String)

### DIFF
--- a/src/gz.jl
+++ b/src/gz.jl
@@ -395,16 +395,15 @@ function read(s::GZipStream, ::Type{String}; bufsize::Int = Z_BIG_BUFSIZE)
     buf = Array{UInt8}(undef, bufsize)
     len = 0
     while true
-        ret = gzread(s, pointer(buf)+len, bufsize)
+        ret = gzread(s, pointer(buf)+len, length(buf)-len)
         if ret == 0
-            if length(buf) > len
-                resize!(buf, len)
-            end
+            resize!(buf, len)
             return String(copy(buf))
         end
         len += ret
-        # Grow the buffer so that bufsize bytes will fit
-        resize!(buf, bufsize+len)
+        if len == length(buf)
+            resize!(buf, max(length(buf) * 2, bufsize))
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- `read(s::GZipStream, String)` grew its internal buffer by a fixed `bufsize` each iteration, causing O(n) resizes for large files
- Switched to exponential doubling (`length(buf) * 2`) to match the pattern already used by `read(s::GZipStream)` for `UInt8` vectors
- Also reads into the full available buffer space each iteration instead of always requesting exactly `bufsize` bytes

## Test plan

- [x] All existing tests pass (both zlib and zlib-ng backends)
- [x] String round-trip already covered by "Compress and decompress" tests (`read(x, String)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)