### PR TITLE
Fix stale module docstring and README recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,13 @@ end
 
 Files are cross-compatible between backends.
 
-## GZip.jl vs CodecZlib.jl
-
-Both packages use zlib under the hood but serve different use cases:
-
-| | GZip.jl | CodecZlib.jl |
-|:---|:---|:---|
-| **Best for** | File-based gzip I/O | In-memory compression, streaming pipelines |
-| **API style** | Drop-in `IO` replacement (`read`, `write`, `seek`) | TranscodingStreams (`transcode`, composable codecs) |
-| **zlib-ng support** | Yes (default backend) | No |
-| **Seeking** | Yes | No |
-| **In-memory compress/decompress** | No | Yes (`transcode`) |
-| **Raw deflate/zlib format** | No (gzip only) | Yes |
-| **Header metadata** | Yes (`gzheader`) | No |
+## When to use GZip.jl
 
 **Use GZip.jl** when you need file-oriented gzip I/O with seeking, zlib-ng performance, or header metadata access.
 
-**Use [ChunkCodecLibZlib.jl](https://github.com/JuliaIO/ChunkCodecs.jl/tree/main/LibZlib)** when you need one-shot in-memory compression with configurable compression level and output size hints.
+**Use [ChunkCodecLibZlib.jl](https://github.com/JuliaIO/ChunkCodecs.jl/tree/main/LibZlib)** for one-shot in-memory compression with configurable compression level and output size hints.
+
+**Use [CodecZlib.jl](https://github.com/JuliaIO/CodecZlib.jl)** for composable streaming pipelines, raw deflate/zlib formats, or TranscodingStreams integration.
 
 ## Documentation
 

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -8,8 +8,9 @@ This module provides a wrapper for the gzip related functions of
 unencumbered, lossless data-compression library. These functions allow
 the reading and writing of gzip files.
 
-Supports both standard zlib (default) and zlib-ng backends. Use
-`backend=GZip.ZLIBNG` when opening files to use the zlib-ng backend.
+Defaults to the [zlib-ng](https://github.com/zlib-ng/zlib-ng) backend for
+faster compression and decompression. Use `backend=GZip.ZLIB` to use standard
+zlib instead. Files are cross-compatible between backends.
 
 ## Notes
 
@@ -38,6 +39,10 @@ following `IO`/`IOStream` functions are supported:
 -   `readline()`
 -   `write()`
 -   `peek()`
+-   `isreadable()`
+-   `iswritable()`
+
+[`gzheader`](@ref) reads gzip header metadata without decompressing.
 
 Due to limitations in `zlib`, `seekend` and `truncate` are not available.
 """


### PR DESCRIPTION
## Summary

- Fix module docstring in `src/GZip.jl` that incorrectly stated zlib was the default backend (zlib-ng is the default since v0.7)
- Add `isreadable()`, `iswritable()`, and `gzheader` to the module docstring's supported functions list
- Replace the CodecZlib.jl comparison table in README with a concise "When to use" section that covers GZip.jl, ChunkCodecLibZlib.jl, and CodecZlib.jl — the old table was disconnected from the ChunkCodecLibZlib recommendation below it

## Test plan

- [x] All tests pass
- [x] Docs-only changes, no code behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)