### PR TITLE
Code quality: concrete types, fix docstrings, remove dead dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,10 @@ authors = ["staticfloat@gmail.com <staticfloat@gmail.com>", "Viral B. Shah <vira
 version = "0.7.0"
 
 [deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 ZlibNG_jll = "c62bbaca-5768-5b75-85e2-9a0ea54e1624"
 
 [compat]
-Libdl = "1.0"
 Zlib_jll = "1.2"
 ZlibNG_jll = "2"
 Aqua = "0.8"

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -8,8 +8,9 @@ This module provides a wrapper for the gzip related functions of
 unencumbered, lossless data-compression library. These functions allow
 the reading and writing of gzip files.
 
-Supports both standard zlib (default) and zlib-ng backends. Use
-`backend=GZip.ZLIBNG` when opening files to use the zlib-ng backend.
+Defaults to the [zlib-ng](https://github.com/zlib-ng/zlib-ng) backend for
+faster compression and decompression. Use `backend=GZip.ZLIB` to use standard
+zlib instead. Files are cross-compatible between backends.
 
 ## Notes
 
@@ -38,12 +39,15 @@ following `IO`/`IOStream` functions are supported:
 -   `readline()`
 -   `write()`
 -   `peek()`
+-   `isreadable()`
+-   `iswritable()`
+
+[`gzheader`](@ref) reads gzip header metadata without decompressing.
 
 Due to limitations in `zlib`, `seekend` and `truncate` are not available.
 """
 module GZip
 
-using Libdl
 using Base.Libc
 
 import Base: show, fd, close, flush, truncate, seek,

--- a/src/gz.jl
+++ b/src/gz.jl
@@ -15,7 +15,7 @@ Subtype of `IO` which wraps a gzip stream. Returned by [`gzopen`](@ref) and
 [`gzdopen`](@ref). Parameterized by the backend (`ZlibBackend` or `ZlibNGBackend`).
 """
 mutable struct GZipStream{B<:GZBackend} <: IO
-    name::AbstractString
+    name::String
     gz_file::GZFile
     buf_size::Int
     backend::B
@@ -23,7 +23,7 @@ mutable struct GZipStream{B<:GZBackend} <: IO
     _write::Bool
 
     function GZipStream(name::AbstractString, gz_file::GZFile, buf_size::Int, backend::B, write::Bool=false) where {B<:GZBackend}
-        x = new{B}(name, gz_file, buf_size, backend, false, write)
+        x = new{B}(String(name), gz_file, buf_size, backend, false, write)
         finalizer(close, x)
         x
     end
@@ -57,13 +57,13 @@ gzip error number and string. Possible error values:
 |  `Z_BUF_ERROR`       |  Input buffer full/output buffer empty                    |
 |  `Z_VERSION_ERROR`   |  zlib library version is incompatible with caller version |
 """
-mutable struct GZError <: Exception
+struct GZError <: Exception
     err::Int32
-    err_str::AbstractString
+    err_str::String
 
-    GZError(e::Integer, str::AbstractString) = new(Int32(e), str)
-    GZError(e::Integer, s::GZipStream) = (a = gzerror(e, s); new(a[1], a[2]))
-    GZError(s::GZipStream) = (a = gzerror(s); new(a[1], a[2]))
+    GZError(e::Integer, str::AbstractString) = new(Int32(e), String(str))
+    GZError(e::Integer, s::GZipStream) = (a = gzerror(e, s); new(a[1], String(a[2])))
+    GZError(s::GZipStream) = (a = gzerror(s); new(a[1], String(a[2])))
 end
 
 # ZError constructor needs backend for gz_zerror dispatch
@@ -239,7 +239,7 @@ function gzopen(fname::AbstractString, gzmode::AbstractString, gz_buf_size::Inte
             gz_buf_size = Z_DEFAULT_BUFSIZE
         end
     end
-    iswrite = occursin(r"[wa]", gzmode)
+    iswrite = ('w' in gzmode || 'a' in gzmode)
     s = GZipStream(fname, gz_file, gz_buf_size, backend, iswrite)
     iswrite || peek(s) # Set EOF-bit for empty files (read mode only)
     return s
@@ -293,7 +293,7 @@ function gzdopen(name::AbstractString, fd::Integer, gzmode::AbstractString, gz_b
             gz_buf_size = Z_DEFAULT_BUFSIZE
         end
     end
-    iswrite = occursin(r"[wa]", gzmode)
+    iswrite = ('w' in gzmode || 'a' in gzmode)
     s = GZipStream(name, gz_file, gz_buf_size, backend, iswrite)
     iswrite || peek(s) # Set EOF-bit for empty files (read mode only)
     return s

--- a/src/zlib.jl
+++ b/src/zlib.jl
@@ -33,9 +33,9 @@ const ZFileOffset = Zlib_h.z_off_t
 
 zlib error, containing an error code and message string.
 """
-mutable struct ZError <: Exception
+struct ZError <: Exception
     err::Cint
-    err_str::AbstractString
+    err_str::String
 end
 
 # --- Backend abstraction ---
@@ -51,14 +51,14 @@ abstract type GZBackend end
 """
     ZlibBackend <: GZBackend
 
-Default backend using the standard zlib library (Zlib_jll).
+Standard zlib backend (Zlib_jll). Use `backend=GZip.ZLIB` to select.
 """
 struct ZlibBackend <: GZBackend end
 
 """
     ZlibNGBackend <: GZBackend
 
-Alternative backend using zlib-ng (ZlibNG_jll), a high-performance fork of zlib.
+Default backend using zlib-ng (ZlibNG_jll), a high-performance fork of zlib.
 """
 struct ZlibNGBackend <: GZBackend end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,7 +222,7 @@ function run_backend_tests(; backend=GZip.ZLIB)
 
                 # Ordered array
                 b = zeros(T, BUFSIZE)
-                if !isa(T, Complex)
+                if !(T <: Complex)
                     for i = 1:length(b)
                         b[i] = (i-1)%minval;
                     end
@@ -233,14 +233,13 @@ function run_backend_tests(; backend=GZip.ZLIB)
                 end
 
                 # Random array
-                if isa(T, AbstractFloat)
-                    r = (T)[rand(BUFSIZE)...];
-                elseif isa(T, ComplexF32)
-                    r = Int32[rand(BUFSIZE)...] + Int32[rand(BUFSIZE)...] * im
-                elseif isa(T, ComplexF64)
-                    r = Int64[rand(BUFSIZE)...] + Int64[rand(BUFSIZE)...] * im
+                if T <: AbstractFloat
+                    r = T.(rand(BUFSIZE))
+                elseif T <: Complex
+                    RT = real(T)
+                    r = Complex{RT}.(rand(RT, BUFSIZE), rand(RT, BUFSIZE))
                 else
-                    r = b[rand(1:BUFSIZE, BUFSIZE)];
+                    r = b[rand(1:BUFSIZE, BUFSIZE)]
                 end
 
                 # Array file


### PR DESCRIPTION
## Summary

Seven code quality fixes:

1. **Fix swapped backend docstrings** — `ZlibBackend` said "Default", `ZlibNGBackend` said "Alternative"; reversed since v0.7
2. **Fix module docstring** — still said zlib was the default; add `isreadable`/`iswritable`/`gzheader` to function list
3. **Make `GZError`/`ZError` immutable** — fields are never mutated after construction; `struct` instead of `mutable struct`
4. **Concrete `String` in struct fields** — `GZipStream.name`, `GZError.err_str`, `ZError.err_str` used `AbstractString`, preventing type inference
5. **Replace regex with char checks** — `occursin(r"[wa]", gzmode)` → `'w' in gzmode || 'a' in gzmode`
6. **Remove unused `Libdl`** — imported but never used (leftover from pre-JLL era)
7. **Fix test type checks** — `isa(T, Complex)` is always `false` (checks instances, not subtypes); should be `T <: Complex`. Float and Complex random array generation was dead code

Supersedes #124 (docs-only subset of these changes).

## Test plan

- [x] All tests pass (both backends)
- [x] Aqua.jl checks pass (ambiguity, piracy, stale deps, compat bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)