### PR TITLE
Improve docs: gzheader, gzdopen, error handling, structured reference

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,6 @@ makedocs(
         "GZip" => "index.md",
         "Reference" => "reference.md",
     ],
-    warnonly = [:missing_docs],
 )
 
 deploydocs(repo = "github.com/JuliaIO/GZip.jl", devbranch = "master")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,8 +4,9 @@ A Julia interface for gzip functions in [zlib](http://zlib.net), a free,
 general-purpose, legally unencumbered, lossless data-compression library.
 
 GZip.jl provides `GZipStream`, a drop-in `IO` replacement for reading and
-writing gzip (`.gz`) files. It supports both standard zlib and
-[zlib-ng](https://github.com/zlib-ng/zlib-ng) backends.
+writing gzip (`.gz`) files. It defaults to the high-performance
+[zlib-ng](https://github.com/zlib-ng/zlib-ng) backend; standard zlib is
+also available via `backend=GZip.ZLIB`.
 
 ## Installation
 
@@ -72,6 +73,69 @@ GZip.open("small.gz", "wb9") do io
     write(io, data)
 end
 ```
+
+## Header Metadata
+
+[`gzheader`](@ref) reads gzip header fields (RFC 1952) without decompressing:
+
+```julia
+h = gzheader("data.gz")
+h.name     # original filename, or nothing
+h.mtime    # modification time as Unix timestamp (0 = not set)
+h.comment  # file comment, or nothing
+h.os       # OS identifier (0x03 = Unix)
+h.extra    # extra field data, or nothing
+h.is_text  # hint that content is ASCII text
+```
+
+!!! note
+    Files created by GZip.jl (via zlib/zlib-ng) will have `name=nothing` and
+    `mtime=0`, because the zlib `gzopen` API does not set these header fields.
+    Files created by command-line `gzip` typically include the original filename
+    and modification time.
+
+## File Descriptor I/O
+
+[`gzdopen`](@ref) wraps an existing file descriptor as a gzip stream:
+
+```julia
+# Wrap an open IOStream's file descriptor
+raw = open("data.gz", "r")
+gz = gzdopen(fd(raw), "r")
+data = read(gz, String)
+close(gz)
+close(raw)
+```
+
+`gzdopen` duplicates the file descriptor internally, so closing the
+`GZipStream` does not close the original.
+
+## Error Handling
+
+GZip.jl throws three exception types:
+
+- [`GZError`](@ref) — gzip-level errors (corrupt data, stream errors). Contains
+  an error code (`err`) and message (`err_str`).
+- [`ZError`](@ref) — zlib-level errors (version mismatch, memory). Same fields.
+- `SystemError` — OS-level errors (file not found, bad file descriptor).
+
+```julia
+try
+    gzopen("missing.gz") do io
+        read(io, String)
+    end
+catch e
+    if e isa SystemError
+        # file not found, permission denied, etc.
+    elseif e isa GZError
+        # corrupt gzip data, CRC mismatch, etc.
+        println("gzip error $(e.err): $(e.err_str)")
+    end
+end
+```
+
+Corrupt data is typically detected on `read` or `close` (CRC check happens
+at stream close).
 
 ## Backends: zlib-ng and zlib
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -2,16 +2,56 @@
 CurrentModule = GZip
 ```
 
-## Functions
+# API Reference
 
-```@autodocs
-Modules = [GZip]
-Order   = [:function]
+## Module
+
+```@docs
+GZip
+```
+
+## Opening and Closing
+
+```@docs
+gzopen
+gzdopen
+GZip.open
+```
+
+## Header Metadata
+
+```@docs
+gzheader
+GZipHeader
+```
+
+## Low-level I/O
+
+```@docs
+gzgetc
+gzgets
+gzread
+gzungetc
+gzputc
+gzwrite
+gzbuffer
 ```
 
 ## Types
 
-```@autodocs
-Modules = [GZip]
-Order   = [:type]
+```@docs
+GZipStream
+GZBackend
+ZlibBackend
+ZlibNGBackend
+ZLIB
+ZLIBNG
+ZFileOffset
+```
+
+## Errors
+
+```@docs
+GZError
+ZError
 ```


### PR DESCRIPTION
## Summary

- Add **Header Metadata** section with `gzheader` usage and a note that zlib-created files won't have FNAME/MTIME set
- Add **File Descriptor I/O** section with `gzdopen` example
- Add **Error Handling** section covering `GZError`, `ZError`, `SystemError` with try/catch example
- Fix intro paragraph to state zlib-ng is the default backend
- Restructure `reference.md` from flat `@autodocs` dump to grouped sections (Opening, Header, Low-level I/O, Types, Errors)
- Remove `warnonly=[:missing_docs]` from `make.jl` — all docstrings now resolve cleanly

## Test plan

- [x] `julia --project=docs docs/make.jl` builds with no errors or warnings
- [x] All package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)