### PR TITLE
Recommend CodecZlib more in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaio.github.io/GZip.jl/dev)
 [![CI](https://github.com/JuliaIO/GZip.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaIO/GZip.jl/actions/workflows/CI.yml)
 
-A Julia interface for gzip functions in [zlib](http://zlib.net). Provides `GZipStream`, a drop-in `IO` replacement for reading and writing gzip files.
+A Julia interface for gzip functions in [zlib](http://zlib.net). Provides `GZipStream` for reading and writing gzip files, with zlib-ng support and gzip header metadata access.
 
 Defaults to the [zlib-ng](https://github.com/zlib-ng/zlib-ng) backend for up to 2.5x faster compression. Standard zlib is also available via `backend=GZip.ZLIB`.
 
@@ -38,19 +38,23 @@ Files are cross-compatible between backends.
 
 ## GZip.jl vs CodecZlib.jl
 
-Both packages use zlib under the hood but serve different use cases:
+**For most users, we recommend [CodecZlib.jl](https://github.com/JuliaIO/CodecZlib.jl).** It provides a more complete and well-tested `IO` interface via [TranscodingStreams.jl](https://github.com/JuliaIO/TranscodingStreams.jl), supports in-memory compression, and handles gzip, zlib, and raw deflate formats.
+
+GZip.jl is a thin wrapper around zlib's `gz*` C functions, which handle file I/O and paths directly in C rather than through Julia's `IOStream`. This means GZip.jl does not benefit from the ongoing work in Base Julia to make file I/O and path handling behave consistently across all supported platforms. It is useful if you specifically need zlib-ng performance or gzip header metadata access, but its `IO` implementation is less complete and less widely tested (8 direct dependents vs CodecZlib.jl's 149).
 
 | | GZip.jl | CodecZlib.jl |
 |:---|:---|:---|
-| **Best for** | File-based gzip I/O | In-memory compression, streaming pipelines |
-| **API style** | Drop-in `IO` replacement (`read`, `write`, `seek`) | TranscodingStreams (`transcode`, composable codecs) |
+| **Recommended for most users** | | **Yes** |
+| **IO interface completeness** | Partial | Full (via TranscodingStreams) |
+| **Best for** | File-based gzip I/O | General-purpose streaming compression |
 | **zlib-ng support** | Yes (default backend) | No |
-| **Seeking** | Yes | No |
-| **In-memory compress/decompress** | No | Yes (`transcode`) |
+| **In-memory compress/decompress** | No | Yes |
 | **Raw deflate/zlib format** | No (gzip only) | Yes |
 | **Header metadata** | Yes (`gzheader`) | No |
 
-**Use GZip.jl** when you need file-oriented gzip I/O with seeking, zlib-ng performance, or header metadata access.
+**Use GZip.jl** when you need zlib-ng performance or gzip header metadata access.
+
+**Use Inflate.jl** if you want a pure Julia library for header metadata access and decompression.
 
 **Use [ChunkCodecLibZlib.jl](https://github.com/JuliaIO/ChunkCodecs.jl/tree/main/LibZlib)** when you need one-shot in-memory compression with configurable compression level and output size hints.
 


### PR DESCRIPTION
At least with the current state of things I don't think we can call `GZipStream` a drop in `IO` replacement without a lot more tests to ensure it behaves like other `IO` types in all the different edge cases.

Also, the gzip format inherently doesn't support seeking, so even though the `seek` function will run, it is emulated and can be extremely slow. This kind of seeking is also supported by CodecZlib, but requires explicitly resetting the stream and skipping forward.

I also added a mention for Inflate.jl as a pure julia alternative.