### PR TITLE
Remove strange methods

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -68,19 +68,6 @@ export
 # IO functions (open is not exported; use GZip.open)
   gzopen,
   gzdopen,
-  fd,
-  close,
-  flush,
-  truncate,
-  seek,
-  skip,
-  position,
-  eof,
-  read,
-  readline,
-  write,
-  unsafe_write,
-  peek,
 
 # Errors
   GZError,

--- a/src/gz.jl
+++ b/src/gz.jl
@@ -360,21 +360,6 @@ function peek(s::GZipStream)
     c
 end
 
-# Mimics read(s::IOStream, a::Array{T})
-function read(s::GZipStream, a::Array{T}) where {T}
-    if isbitstype(T)
-        nb = length(a)*sizeof(T)
-        ret = gzread(s, pointer(a), nb)
-        if ret < nb
-            throw(EOFError())
-        end
-        peek(s) # force eof to be set
-        a
-    else
-        invoke(read!, Tuple{IO,Array}, s, a)
-    end
-end
-
 function read(s::GZipStream, ::Type{UInt8})
     ret = gzgetc(s)  # throws EOFError or GZError on failure
     peek(s) # force eof to be set
@@ -390,24 +375,6 @@ function read(s::GZipStream; bufsize::Int = Z_BIG_BUFSIZE)
         if ret == 0
             resize!(buf, len)
             return buf
-        end
-        len += ret
-        if len == length(buf)
-            resize!(buf, max(length(buf) * 2, bufsize))
-        end
-    end
-end
-
-# For this function, it's really unfortunate that zlib is
-# not integrated with ios
-function read(s::GZipStream, ::Type{String}; bufsize::Int = Z_BIG_BUFSIZE)
-    buf = Array{UInt8}(undef, bufsize)
-    len = 0
-    while true
-        ret = gzread(s, pointer(buf)+len, length(buf)-len)
-        if ret == 0
-            resize!(buf, len)
-            return String(copy(buf))
         end
         len += ret
         if len == length(buf)
@@ -459,7 +426,6 @@ function readline(s::GZipStream; keep::Bool=false)
 end
 
 write(s::GZipStream, b::UInt8) = (gzputc(s, b); 1)
-write(s::GZipStream, a::Array{UInt8}) = Int(gzwrite(s, pointer(a), sizeof(a)))
 unsafe_write(s::GZipStream, p::Ptr{UInt8}, nb::UInt) = Int(gzwrite(s, p, nb))
 
 # ---------------------------------------------------------------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,11 +260,11 @@ function run_backend_tests(; backend=GZip.ZLIB)
                 r2 = zeros(T, BUFSIZE)
 
                 b2_infile = gzopen(b_array_fn; backend)
-                read(b2_infile, b2);
+                read!(b2_infile, b2);
                 close(b2_infile)
 
                 r2_infile = gzopen(r_array_fn; backend)
-                read(r2_infile, r2);
+                read!(r2_infile, r2);
                 close(r2_infile)
 
                 @test b == b2


### PR DESCRIPTION
Fixes #135 

These methods should not be implemented. The fallbacks in Base are designed to handle these methods.

This PR also removes the reexport of functions that are already exported by Base.